### PR TITLE
feat(mentions): remove what should be invisible coments from messages

### DIFF
--- a/__tests__/modules/slack.test.ts
+++ b/__tests__/modules/slack.test.ts
@@ -19,6 +19,29 @@ describe("modules/slack", () => {
       expect(result.includes("by sender_github_username")).toEqual(true);
       expect(result.includes("> message")).toEqual(true);
     });
+
+    it("should remove comments from message", () => {
+      const result = buildSlackPostMessage(
+        ["slackUser1"],
+        "title",
+        "link",
+        `message
+        <!--
+
+
+        with comment
+
+
+        /-->`,
+        "sender_github_username"
+      );
+
+      expect(result.includes("<@slackUser1> has been mentioned")).toEqual(true);
+      expect(result.includes("<link|title>")).toEqual(true);
+      expect(result.includes("by sender_github_username")).toEqual(true);
+      expect(result.includes("> message")).toEqual(true);
+      expect(result.includes("with comment")).toEqual(false);
+    });
   });
 
   describe("buildSlackErrorMessage", () => {

--- a/src/modules/slack.ts
+++ b/src/modules/slack.ts
@@ -8,10 +8,11 @@ export const buildSlackPostMessage = (
 	senderName: string
 ) => {
 	const mentionBlock = slackIdsForMention.map((id) => `<@${id}>`).join(" ");
-	const body = githubBody
+	let body = githubBody
 		.split("\n")
 		.map((line) => `> ${line}`)
-		.join("\n");
+		.join("\n")
+		.replace(/<!--[\s\S]*?-->/g, ""); // Remove HTML/Markdown comments from message
 
 	const message = [
 		mentionBlock,


### PR DESCRIPTION
Theres no need to show the large comment sections in our PR templates:

This removes them

<img width="741" alt="Screenshot 2020-11-25 at 17 02 38" src="https://user-images.githubusercontent.com/8436717/100252329-0a2bff00-2f40-11eb-9a54-474a9778e2ab.png">
